### PR TITLE
Add `setprefix` command

### DIFF
--- a/src/commands/features/setprefix.ts
+++ b/src/commands/features/setprefix.ts
@@ -1,0 +1,30 @@
+import { Command } from '@/types';
+
+import { getPrefix, setPrefix } from '@/handler/data';
+
+const setprefix: Command = {
+  name: 'setprefix',
+  aliases: [],
+  usage: 'setprefix',
+  description: 'setprefix',
+  execute(msg, args) {
+    if (args.length < 1) {
+      msg.channel.send('請指定前綴！');
+      return;
+    }
+
+    const prefix = args[0].trim();
+
+    if (!prefix) {
+      msg.channel.send('無效前綴！');
+      return;
+    }
+
+    const oldPrefix = getPrefix().trim();
+    setPrefix(prefix);
+
+    msg.channel.send(`成功將指令前綴由 \`${oldPrefix}\` 改為 \`${prefix}\` ！`);
+  },
+};
+
+export default setprefix;

--- a/src/handler/commands.ts
+++ b/src/handler/commands.ts
@@ -3,10 +3,11 @@ import { Client, Message } from 'discord.js';
 import count from '@/commands/features/count';
 import notify from '@/commands/features/notify';
 import cancel from '@/commands/features/cancel';
+import setprefix from '@/commands/features/setprefix';
 
 import { getPrefix } from '@/handler/data';
 
-const commands = [count, notify, cancel];
+const commands = [count, notify, cancel, setprefix];
 
 const commandHandler = (msg: Message, client: Client): void => {
   const prefix = getPrefix();


### PR DESCRIPTION
Based on PR #7 

Add `setprefix` command where users can set customized prefix.
Setting prefixes ending with char [A-z0-9_]  would require an additional space after the prefix when using commands.